### PR TITLE
Add health monitor with drain and auto-reboot

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,20 @@ RETENTION_MAX_AGE_MIN=1440
 RETENTION_SWEEP_INTERVAL=300
 MIN_FREE_GB=20
 PURGE_OLDEST_ON_PRESSURE=true
+
+# --- Host health monitor / graceful drain + auto-reboot ---
+# Detect RAM/swap pressure, block new sessions, reboot once idle & recordings done.
+# Tuned for Apple M4 / 24 GB RAM / ~200 GB SSD running ~5 simulators.
+# 24 GB is memory-tight for 5 sims, so pressure escalates fast -> trigger a bit
+# earlier and cap the drain wait shorter than the generic defaults.
+HEALTH_ENABLED=true
+HEALTH_CHECK_INTERVAL=60
+HEALTH_MIN_UPTIME_MIN=30
+HEALTH_UNHEALTHY_STREAK=3
+# ~5 GB swap in use on a 24 GB host = real over-commit; act before it thrashes.
+HEALTH_SWAP_USED_MAX_MB=5120
+# <=10% available (~2.4 GB) is the low-headroom secondary trigger for 24 GB.
+HEALTH_MEM_FREE_MIN_PCT=10
+# M4 + SSD drains recordings/transcodes fast; force reboot after 20 min if stuck.
+HEALTH_DRAIN_TIMEOUT=1200
+HEALTH_REBOOT_CMD="sudo /sbin/shutdown -r now"

--- a/LaunchAgents/ZebrunnerHealthMonitor.plist
+++ b/LaunchAgents/ZebrunnerHealthMonitor.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+	"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>EnvironmentVariables</key>
+		<dict>
+			<key>PATH</key>
+			<string>/bin:/usr/bin:/usr/local/bin:/usr/sbin:/sbin</string>
+		</dict>
+		<key>Label</key>
+		<string>com.zebrunner.mcloud.health</string>
+		<key>ProgramArguments</key>
+		<array>
+			<string>./health-monitor.sh</string>
+		</array>
+		<key>WorkingDirectory</key>
+		<string>working_dir_value</string>
+		<key>UserName</key>
+		<string>user_value</string>
+
+		<key>KeepAlive</key>
+		<true/>
+
+		<key>RunAtLoad</key>
+		<true/>
+
+		<key>AbandonProcessGroup</key>
+		<true/>
+
+		<key>StartInterval</key>
+		<integer>0</integer>
+
+		<key>StandardErrorPath</key>
+		<string>logs/health-monitor.log</string>
+		<key>StandardOutPath</key>
+		<string>logs/health-monitor.log</string>
+	</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,55 @@ Phone_X1         | 7643aa9bd1638255f48ca6beac4285cae4f6454g | com.facebook.WebDr
 
 * Execute `./zebrunner.sh` to see all available actions
 
+## Health monitor and auto-reboot
+
+Long regression runs on a host with several simulators, Appium servers, Docker
+containers and native screen recording gradually exhaust RAM/swap until the host
+becomes unresponsive and drops off the grid/STF. A background health monitor
+(`health-monitor.sh`, installed as the `ZebrunnerHealthMonitor` LaunchAgent
+during `./zebrunner.sh setup`) prevents this:
+
+1. It samples memory/swap pressure on an interval.
+2. When the host stays unhealthy for several samples it enters **drain** mode:
+   new sessions are blocked (idle Appium nodes are killed so the grid stops
+   routing to them) while sessions already in progress are allowed to finish.
+3. Once there are no active sessions **and** all screen recording/transcoding is
+   done, it reboots the host. After reboot every service auto-starts via the
+   existing LaunchAgents, so a well-timed reboot restores a clean environment.
+
+The drain flag is boot-time-aware, so a flag left over from before the reboot is
+automatically ignored and services are never blocked from starting afterwards.
+
+Configuration (in `.env`):
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `HEALTH_ENABLED` | `true` | Master switch for the monitor |
+| `HEALTH_CHECK_INTERVAL` | `60` | Seconds between samples |
+| `HEALTH_MIN_UPTIME_MIN` | `30` | Grace period after boot before it may act |
+| `HEALTH_UNHEALTHY_STREAK` | `3` | Consecutive unhealthy samples before draining |
+| `HEALTH_SWAP_USED_MAX_MB` | `6144` | Swap used ≥ this ⇒ unhealthy (`0` disables) |
+| `HEALTH_MEM_FREE_MIN_PCT` | `8` | Available RAM ≤ this % ⇒ unhealthy (`0` disables) |
+| `HEALTH_DRAIN_TIMEOUT` | `1800` | Force reboot after draining this long (stuck session safety valve) |
+| `HEALTH_REBOOT_CMD` | `sudo /sbin/shutdown -r now` | Command used to reboot |
+
+Prerequisites:
+
+* Auto-login must be enabled (see above) so LaunchAgents reload after the reboot.
+* The reboot must run **without a password prompt**. Grant passwordless sudo for
+  `shutdown`, e.g. add a file `/etc/sudoers.d/zebrunner-reboot` (via `sudo visudo -f`):
+
+  ```
+  <your-user> ALL=(root) NOPASSWD: /sbin/shutdown
+  ```
+
+Manual controls / observability:
+
+* `./zebrunner.sh health` — print current memory/swap health and drain state
+* `./zebrunner.sh drain` — manually drain and reboot once the host is idle
+* `./zebrunner.sh undrain` — cancel a pending drain
+* Monitor activity is logged to `logs/health-monitor.log`
+
 ## Documentation and free support
 * [Zebrunner PRO](https://zebrunner.com)
 * [Zebrunner CE](https://zebrunner.github.io/community-edition)

--- a/configs/health-common.sh
+++ b/configs/health-common.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# health-common.sh
+#
+# Shared helpers for the host health monitor / graceful-drain mechanism.
+#
+# This file is meant to be SOURCED (no side effects on load beyond defining
+# functions and default variables). It is sourced by both:
+#   - zebrunner.sh          (to make start-device drain-aware)
+#   - health-monitor.sh     (the daemon that detects pressure and reboots)
+#
+# The "drain" concept:
+#   When the host is under memory/swap pressure the monitor creates a drain
+#   flag. While draining, new Appium sessions must not be started. Idle Appium
+#   servers are killed (which deregisters their node from the Selenium grid so
+#   no new sessions are routed to them), busy ones are left to finish. Once all
+#   sessions ended and all screen-recording/transcoding finished, the host is
+#   rebooted. After reboot every service auto-starts again via the existing
+#   LaunchAgents, so a well-timed reboot recovers the environment.
+#
+# Boot-time-aware flag:
+#   The drain flag is considered ACTIVE only when its modification time is newer
+#   than the last system boot. This means a flag left over from before a reboot
+#   is automatically treated as stale (and removed), so services are NOT blocked
+#   from starting after the recovery reboot. No explicit cross-reboot cleanup is
+#   required.
+
+# Resolve base dir (repo root) whether BASEDIR is preset by the caller or not.
+_HC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${BASEDIR:=$_HC_DIR}"
+
+# Drain flag lives under metaData (created during setup, local to the host).
+export DRAIN_FLAG="${BASEDIR}/metaData/.drain"
+
+# ---- Tunables (overridable via .env; sane defaults if unset) ----------------
+: "${HEALTH_ENABLED:=true}"
+: "${HEALTH_CHECK_INTERVAL:=60}"       # seconds between samples
+: "${HEALTH_MIN_UPTIME_MIN:=30}"       # do not act until host has been up this long
+: "${HEALTH_UNHEALTHY_STREAK:=3}"      # consecutive unhealthy samples before draining
+: "${HEALTH_SWAP_USED_MAX_MB:=6144}"   # swap used >= this => unhealthy (0 disables)
+: "${HEALTH_MEM_FREE_MIN_PCT:=8}"      # available RAM <= this % => unhealthy (0 disables)
+: "${HEALTH_DRAIN_TIMEOUT:=1800}"      # force reboot after draining this long (seconds)
+: "${HEALTH_REBOOT_CMD:=sudo /sbin/shutdown -r now}"
+
+# Cross-call scratch values populated by is_host_unhealthy().
+export HEALTH_LAST=""
+export HEALTH_REASON=""
+
+hc_timestamp() { date "+%Y-%m-%dT%H:%M:%S%z"; }
+
+hc_log() {
+  echo "[$(hc_timestamp)] [health] $*"
+}
+
+# Epoch seconds of the last system boot.
+boot_epoch() {
+  # kern.boottime: "{ sec = 1712345678, usec = 0 } Wed ..."
+  # Anchor on the trailing comma so we capture sec (not usec, which ends in " }").
+  sysctl -n kern.boottime 2>/dev/null | sed -n 's/.*sec = \([0-9][0-9]*\),.*/\1/p'
+}
+
+# Host uptime in whole minutes.
+uptime_minutes() {
+  local bt now
+  bt="$(boot_epoch)"
+  now="$(date +%s)"
+  if [ -z "$bt" ]; then
+    echo 999999
+    return 0
+  fi
+  echo $(( (now - bt) / 60 ))
+}
+
+# True (0) when a drain is currently active (flag exists AND is newer than boot).
+# A stale pre-reboot flag is removed and reported as inactive.
+is_drain_active() {
+  [ -f "$DRAIN_FLAG" ] || return 1
+  local fm bt
+  fm="$(stat -f %m "$DRAIN_FLAG" 2>/dev/null || echo 0)"
+  bt="$(boot_epoch)"
+  if [ -n "$bt" ] && [ "$fm" -ge "$bt" ]; then
+    return 0
+  fi
+  # stale flag from a previous boot -> drop it so services can start
+  rm -f "$DRAIN_FLAG" 2>/dev/null || true
+  return 1
+}
+
+set_drain() {
+  mkdir -p "$(dirname "$DRAIN_FLAG")" 2>/dev/null || true
+  {
+    echo "reason=${HEALTH_REASON}"
+    echo "at=$(hc_timestamp)"
+    echo "epoch=$(date +%s)"
+  } > "$DRAIN_FLAG" 2>/dev/null || true
+  # ensure mtime is 'now' (newer than boot)
+  touch "$DRAIN_FLAG" 2>/dev/null || true
+}
+
+clear_drain() {
+  rm -f "$DRAIN_FLAG" 2>/dev/null || true
+}
+
+# Epoch seconds the current drain started (flag mtime); empty if not draining.
+drain_started_epoch() {
+  [ -f "$DRAIN_FLAG" ] || return 1
+  stat -f %m "$DRAIN_FLAG" 2>/dev/null
+}
+
+# ---- Memory / swap sampling -------------------------------------------------
+
+# Swap used, in whole MB.
+swap_used_mb() {
+  local s used
+  s="$(sysctl -n vm.swapusage 2>/dev/null)"
+  # e.g. "total = 3072.00M  used = 2500.00M  free = 572.00M"
+  used="$(echo "$s" | sed -n 's/.*used = \([0-9.]*\)M.*/\1/p')"
+  used="${used%%.*}"
+  echo "${used:-0}"
+}
+
+# Available (free+inactive+speculative+purgeable) RAM as a percentage of total.
+mem_free_pct() {
+  local page_size mem_total vm free inactive spec purge available avail_bytes
+  page_size="$(sysctl -n hw.pagesize 2>/dev/null)"
+  mem_total="$(sysctl -n hw.memsize 2>/dev/null)"
+  vm="$(vm_stat 2>/dev/null)"
+  if [ -z "$page_size" ] || [ -z "$mem_total" ] || [ -z "$vm" ]; then
+    echo 100
+    return 0
+  fi
+  _hc_pages() { echo "$vm" | grep -i "$1" | head -1 | awk '{print $NF}' | tr -d '.'; }
+  free="$(_hc_pages 'Pages free')"
+  inactive="$(_hc_pages 'Pages inactive')"
+  spec="$(_hc_pages 'Pages speculative')"
+  purge="$(_hc_pages 'Pages purgeable')"
+  available=$(( ${free:-0} + ${inactive:-0} + ${spec:-0} + ${purge:-0} ))
+  avail_bytes=$(( available * page_size ))
+  if [ "$mem_total" -le 0 ]; then
+    echo 100
+    return 0
+  fi
+  echo $(( avail_bytes * 100 / mem_total ))
+}
+
+# True (0) when the host is under memory/swap pressure. Populates HEALTH_LAST
+# and HEALTH_REASON for logging.
+is_host_unhealthy() {
+  local swap_used free_pct reasons=""
+  swap_used="$(swap_used_mb)"
+  free_pct="$(mem_free_pct)"
+  HEALTH_LAST="swap_used=${swap_used}MB free_ram=${free_pct}%"
+
+  if [ "${HEALTH_SWAP_USED_MAX_MB:-0}" -gt 0 ] 2>/dev/null && \
+     [ "${swap_used:-0}" -ge "${HEALTH_SWAP_USED_MAX_MB}" ] 2>/dev/null; then
+    reasons="swap_used=${swap_used}MB>=${HEALTH_SWAP_USED_MAX_MB}MB"
+  fi
+  if [ "${HEALTH_MEM_FREE_MIN_PCT:-0}" -gt 0 ] 2>/dev/null && \
+     [ "${free_pct:-100}" -le "${HEALTH_MEM_FREE_MIN_PCT}" ] 2>/dev/null; then
+    if [ -n "$reasons" ]; then reasons="${reasons}, "; fi
+    reasons="${reasons}free_ram=${free_pct}%<=${HEALTH_MEM_FREE_MIN_PCT}%"
+  fi
+
+  if [ -n "$reasons" ]; then
+    HEALTH_REASON="$reasons"
+    return 0
+  fi
+  HEALTH_REASON=""
+  return 1
+}
+
+# ---- Session / recording state ---------------------------------------------
+
+# Prints "udid|appium_port" for each configured device (skips header row).
+# devices.txt columns: name | udid | wda_bundle_id | wda_port | mjpeg_port | appium_port
+list_device_udid_port() {
+  local devices_file="${BASEDIR}/devices.txt"
+  [ -f "$devices_file" ] || return 0
+  while IFS= read -r line; do
+    local udid port
+    udid="$(echo "$line" | cut -d '|' -f 2 | tr -d '[:space:]')"
+    port="$(echo "$line" | cut -d '|' -f 6 | tr -d '[:space:]')"
+    [ -z "$udid" ] && continue
+    [ "$udid" = "UDID" ] && continue
+    echo "${udid}|${port}"
+  done < "$devices_file"
+}
+
+# True (0) when the Appium node on the given port currently has an active session.
+# Unknown/unreachable Appium (node down) is treated as "no session".
+device_has_active_session() {
+  local port="$1"
+  [ -n "$port" ] || return 1
+  local body
+  body="$(curl -fsS -m 5 "http://localhost:${port}/wd/hub/sessions" 2>/dev/null)" || return 1
+  if command -v jq >/dev/null 2>&1; then
+    echo "$body" | jq -e '(.value | length) > 0' >/dev/null 2>&1 && return 0 || return 1
+  fi
+  # Fallback without jq: empty session list looks like "value":[]
+  echo "$body" | grep -q '"value"[[:space:]]*:[[:space:]]*\[[[:space:]]*{' && return 0 || return 1
+}
+
+# Kill only the Appium process bound to a given udid (deregisters its grid node).
+# Mirrors the filters used by zebrunner.sh stop-appium so WDA is not touched.
+deregister_idle_appium() {
+  local udid="$1"
+  [ -n "$udid" ] || return 0
+  local pids
+  pids="$(ps -eaf | grep "$udid" | grep 'appium' | grep -v grep \
+    | grep -v 'stop-appium' | grep -v '/stf' | grep -v '/usr/share/maven' \
+    | grep -v 'WebDriverAgent' | grep -v 'health-monitor' | awk '{print $2}')"
+  if [ -n "$pids" ]; then
+    hc_log "Deregistering idle Appium for ${udid} (pids: ${pids})"
+    kill -9 $pids 2>/dev/null || true
+  fi
+}
+
+# True (0) when any screen recording or video transcoding is still in progress.
+recording_in_progress() {
+  # Active simulator screen recording
+  pgrep -f 'simctl io .* recordVideo' >/dev/null 2>&1 && return 0
+  # Active transcoding
+  pgrep -f 'ffmpeg' >/dev/null 2>&1 && return 0
+  # Pending transcode jobs or in-flight recordings tracked by the watcher
+  local f
+  for f in "${BASEDIR}"/recording/tmp/*/transcoder-jobs-*.list; do
+    [ -f "$f" ] && [ -s "$f" ] && return 0
+  done
+  for f in "${BASEDIR}"/recording/tmp/*/rec-*.pid; do
+    [ -f "$f" ] && return 0
+  done
+  return 1
+}

--- a/health-monitor.sh
+++ b/health-monitor.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# health-monitor.sh
+#
+# Host health monitor with graceful drain + auto-reboot recovery.
+#
+# Problem it solves:
+#   A Mac hosting several iOS simulators + Appium servers + Docker containers +
+#   native screen recording gradually exhausts RAM/swap during long regression
+#   runs and eventually becomes unresponsive (loses connection to grid/STF).
+#
+# What it does:
+#   1. Periodically samples memory/swap pressure (see configs/health-common.sh).
+#   2. When the host stays unhealthy for HEALTH_UNHEALTHY_STREAK samples it
+#      enters DRAIN mode (creates a boot-time-aware drain flag).
+#   3. While draining it kills idle Appium nodes (so the grid stops routing new
+#      sessions to them) and leaves busy nodes to finish their current session.
+#      The drain flag prevents the recovery LaunchAgents from restarting the
+#      killed nodes.
+#   4. Once there are no active sessions AND all recording/transcoding finished
+#      (or HEALTH_DRAIN_TIMEOUT elapsed) it reboots the host.
+#   5. After reboot the existing LaunchAgents auto-start every service again and
+#      the drain flag is automatically stale (older than boot), so the host
+#      comes back fully operational.
+#
+# Run as a LaunchAgent (see LaunchAgents/ZebrunnerHealthMonitor.plist).
+
+set -uo pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${BASEDIR}"
+
+# Load .env (tunables) then shared helpers.
+if [ -f "${BASEDIR}/.env" ]; then
+  # shellcheck disable=SC1091
+  source "${BASEDIR}/.env"
+fi
+# shellcheck disable=SC1091
+source "${BASEDIR}/configs/health-common.sh"
+
+streak=0
+
+hc_log "Health monitor starting (enabled=${HEALTH_ENABLED} interval=${HEALTH_CHECK_INTERVAL}s streak>=${HEALTH_UNHEALTHY_STREAK} swap_max=${HEALTH_SWAP_USED_MAX_MB}MB free_min=${HEALTH_MEM_FREE_MIN_PCT}% drain_timeout=${HEALTH_DRAIN_TIMEOUT}s)"
+
+if [ "${HEALTH_ENABLED}" != "true" ]; then
+  hc_log "HEALTH_ENABLED != true; monitor idle (no action will be taken)."
+  while true; do sleep 3600; done
+fi
+
+do_reboot() {
+  local why="$1"
+  hc_log "REBOOTING host: ${why}"
+  # Best effort: stop containers/recording gracefully so nothing is left mid-write.
+  # The reboot command itself must be permitted without a password (see README).
+  eval "${HEALTH_REBOOT_CMD}" || hc_log "ERROR: reboot command failed: ${HEALTH_REBOOT_CMD}"
+  # Give the reboot time to take effect; avoid tight relaunch loops.
+  sleep 120
+}
+
+# Progressively drain the host and reboot when it is safe.
+run_drain_step() {
+  local busy=0 idle=0 entry udid port started elapsed now
+
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    udid="${entry%%|*}"
+    port="${entry##*|}"
+    if device_has_active_session "$port"; then
+      busy=$((busy + 1))
+    else
+      idle=$((idle + 1))
+      deregister_idle_appium "$udid"
+    fi
+  done < <(list_device_udid_port)
+
+  local rec="no"
+  if recording_in_progress; then rec="yes"; fi
+
+  hc_log "Draining: busy_sessions=${busy} idle_deregistered=${idle} recording_or_transcoding=${rec}"
+
+  if [ "$busy" -eq 0 ] && [ "$rec" = "no" ]; then
+    do_reboot "drain complete (no active sessions, no pending recordings)"
+    return 0
+  fi
+
+  # Safety valve: an unhealthy host must not stay up forever if a session/record
+  # is stuck. Force the reboot after HEALTH_DRAIN_TIMEOUT.
+  started="$(drain_started_epoch || echo 0)"
+  now="$(date +%s)"
+  elapsed=$(( now - ${started:-$now} ))
+  if [ "${HEALTH_DRAIN_TIMEOUT:-0}" -gt 0 ] 2>/dev/null && [ "$elapsed" -ge "${HEALTH_DRAIN_TIMEOUT}" ]; then
+    do_reboot "drain timeout reached (${elapsed}s >= ${HEALTH_DRAIN_TIMEOUT}s; busy=${busy} recording=${rec})"
+  fi
+}
+
+while true; do
+  up_min="$(uptime_minutes)"
+
+  if [ "${up_min}" -lt "${HEALTH_MIN_UPTIME_MIN}" ] 2>/dev/null; then
+    # Give the host time to settle after a (re)boot before acting.
+    sleep "${HEALTH_CHECK_INTERVAL}"
+    continue
+  fi
+
+  if is_drain_active; then
+    run_drain_step
+    sleep "${HEALTH_CHECK_INTERVAL}"
+    continue
+  fi
+
+  if is_host_unhealthy; then
+    streak=$((streak + 1))
+    hc_log "UNHEALTHY sample ${streak}/${HEALTH_UNHEALTHY_STREAK} (${HEALTH_LAST}; ${HEALTH_REASON})"
+    if [ "${streak}" -ge "${HEALTH_UNHEALTHY_STREAK}" ]; then
+      hc_log "Pressure sustained -> entering DRAIN mode. New sessions will be blocked; host will reboot once idle."
+      set_drain
+      run_drain_step
+    fi
+  else
+    if [ "${streak}" -ne 0 ]; then
+      hc_log "Recovered to healthy (${HEALTH_LAST}); resetting streak."
+    fi
+    streak=0
+  fi
+
+  sleep "${HEALTH_CHECK_INTERVAL}"
+done

--- a/zebrunner.sh
+++ b/zebrunner.sh
@@ -14,6 +14,9 @@ if [ ! -d "${BASEDIR}/metaData" ]; then
     mkdir -p "${BASEDIR}/metaData"
 fi
 
+# shared helpers for host health monitor / graceful drain (defines is_drain_active, etc.)
+source configs/health-common.sh
+
 # udid position in devices.txt to be able to read by sync scripts
 export udid_position=2
 
@@ -52,6 +55,11 @@ export udid_position=2
       launchctl unload $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist > /dev/null 2>&1
     fi
 
+    # unload Health Monitor script if any to avoid restarts during setup
+    if [[ -r $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist ]]; then
+      launchctl unload $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist > /dev/null 2>&1
+    fi
+
     echo 
 
     cd "${BASEDIR}"
@@ -61,6 +69,11 @@ export udid_position=2
     replace $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist "working_dir_value" "${BASEDIR}"
     replace $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist "user_value" "$USER"
     # load asap to be able to start services after whitelisted device connect
+
+    # register host health monitor (memory/swap pressure -> graceful drain -> reboot)
+    cp LaunchAgents/ZebrunnerHealthMonitor.plist $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist
+    replace $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist "working_dir_value" "${BASEDIR}"
+    replace $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist "user_value" "$USER"
 
     #Configure LaunchAgent service per each device for fast recovery
     while read -r line
@@ -118,6 +131,10 @@ export udid_position=2
 
 
     rm -f $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist
+
+    launchctl unload $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist > /dev/null 2>&1
+    rm -f $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist
+    clear_drain
 
     # remove configuration files and LaunchAgents plist(s)
     git checkout -- devices.txt
@@ -212,6 +229,9 @@ export udid_position=2
       exit -1
     fi
 
+    # A manual start overrides any in-progress drain.
+    clear_drain
+
     # verify one by one connected devices and authorized simulators
     while read -r line
     do
@@ -232,6 +252,11 @@ export udid_position=2
 
     launchctl load $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist > /dev/null 2>&1
 
+    # (re)load host health monitor if it is installed and enabled
+    if [ -f $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist ] && [ "${HEALTH_ENABLED:-true}" = "true" ]; then
+      launchctl load $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist > /dev/null 2>&1
+    fi
+
     echo "Verify startup status using './zebrunner.sh status'"
     exit 0
   }
@@ -246,6 +271,14 @@ export udid_position=2
     udid=$1
 
     . ./configs/getDeviceArgs.sh $udid
+
+    # Drain guard: while the host is draining for a maintenance reboot we must
+    # NOT (re)start services, otherwise the recovery LaunchAgent would resurrect
+    # Appium nodes that were just deregistered and the host would never go idle.
+    if is_drain_active; then
+      echo "[$(date +'%d/%m/%Y %H:%M:%S')] [drain] Host is draining for a maintenance reboot; skip starting services for $DEVICE_NAME ($DEVICE_UDID)." >> ${DEVICE_LOG} 2>&1
+      return 0
+    fi
 
     if [ -n "$device" ]; then
       echo "$DEVICE_NAME ($DEVICE_UDID)" >> ${DEVICE_LOG} 2>&1
@@ -524,6 +557,10 @@ export udid_position=2
 
     launchctl unload $HOME/Library/LaunchAgents/ZebrunnerDevicesManager.plist > /dev/null 2>&1
 
+    # stop health monitor and clear any active drain so a later start is not blocked
+    launchctl unload $HOME/Library/LaunchAgents/ZebrunnerHealthMonitor.plist > /dev/null 2>&1
+    clear_drain
+
     wait
     echo "MCloud services stopped."
 
@@ -612,6 +649,8 @@ export udid_position=2
       exit -1
     fi
 
+    health
+
     # verify one by one connected devices and authorized simulators
     while read -r line
     do
@@ -627,6 +666,37 @@ export udid_position=2
     done < ${devices}
 
     wait
+  }
+
+  health() {
+    # Print current host health / drain state (used by 'status' and 'health').
+    local drain_state="off"
+    if is_drain_active; then
+      drain_state="ON (draining for reboot; started $(date -r "$(drain_started_epoch)" '+%Y-%m-%d %H:%M:%S' 2>/dev/null))"
+    fi
+    if is_host_unhealthy; then
+      echo "Host health: UNHEALTHY (${HEALTH_LAST}; ${HEALTH_REASON}) | uptime=$(uptime_minutes)min | drain=${drain_state}"
+    else
+      echo "Host health: healthy (${HEALTH_LAST}) | uptime=$(uptime_minutes)min | drain=${drain_state}"
+    fi
+    # Safe, non-executing check that the reboot command can run without a password.
+    if ! sudo -n -l /sbin/shutdown >/dev/null 2>&1; then
+      echo_warning "Passwordless sudo for /sbin/shutdown is NOT configured; auto-reboot will fail. See README (Health monitor)."
+    fi
+  }
+
+  drain() {
+    # Manually put the host into drain mode (block new sessions, reboot when idle).
+    is_host_unhealthy >/dev/null 2>&1
+    HEALTH_REASON="${HEALTH_REASON:-manual}"
+    set_drain
+    echo "Drain enabled. New sessions are blocked; host will reboot once all sessions end and recordings finish."
+    echo "Monitor progress in logs/health-monitor.log. Cancel with './zebrunner.sh undrain'."
+  }
+
+  undrain() {
+    clear_drain
+    echo "Drain cleared. Run './zebrunner.sh start' (or wait for the recovery agents) to resume services."
   }
 
   status-device() {
@@ -852,6 +922,9 @@ export udid_position=2
           shutdown            Destroy Device Farm iOS agent completely
           backup              Backup Device Farm iOS agent services
           restore             Restore Device Farm iOS agent services
+          health              Show host memory/swap health and drain state
+          drain               Block new sessions and reboot the host once idle (manual maintenance)
+          undrain             Cancel an active/queued drain
           version             Version of Device Farm iOS agent"
       echo_telegram
       exit 0
@@ -955,6 +1028,15 @@ case "$1" in
         ;;
     listen)
         listen
+        ;;
+    health)
+        health
+        ;;
+    drain)
+        drain
+        ;;
+    undrain)
+        undrain
         ;;
     version)
         version


### PR DESCRIPTION
Introduce a host health monitoring flow that detects sustained memory/swap pressure, enters drain mode, deregisters idle Appium nodes, and reboots once sessions and recording/transcoding are complete (or timeout is reached). Added a new LaunchAgent and monitor/common scripts, wired setup/start/stop/shutdown to manage the monitor, and made device startup drain-aware to prevent new work during maintenance. Also added `health`, `drain`, and `undrain` CLI actions, documented the feature and sudo requirement in README, and added new health-related `.env` defaults tuned for this host profile.