### PR TITLE
Use flag-based reboot flow without sudo

### DIFF
--- a/.env
+++ b/.env
@@ -23,4 +23,7 @@ HEALTH_SWAP_USED_MAX_MB=5120
 HEALTH_MEM_FREE_MIN_PCT=10
 # M4 + SSD drains recordings/transcodes fast; force reboot after 20 min if stuck.
 HEALTH_DRAIN_TIMEOUT=1200
-HEALTH_REBOOT_CMD="sudo /sbin/shutdown -r now"
+# No sudo: the monitor only SIGNALS a safe reboot by writing this flag; the
+# existing root scheduler (scheduled-reboot.sh, run from cron/LaunchDaemon)
+# consumes the flag and performs the actual /sbin/shutdown -r now as root.
+HEALTH_REBOOT_CMD="/usr/bin/touch ${BASEDIR}/metaData/.reboot-request"

--- a/README.md
+++ b/README.md
@@ -71,13 +71,32 @@ Configuration (in `.env`):
 | `HEALTH_SWAP_USED_MAX_MB` | `6144` | Swap used ≥ this ⇒ unhealthy (`0` disables) |
 | `HEALTH_MEM_FREE_MIN_PCT` | `8` | Available RAM ≤ this % ⇒ unhealthy (`0` disables) |
 | `HEALTH_DRAIN_TIMEOUT` | `1800` | Force reboot after draining this long (stuck session safety valve) |
-| `HEALTH_REBOOT_CMD` | `sudo /sbin/shutdown -r now` | Command used to reboot |
+| `HEALTH_REBOOT_CMD` | `/usr/bin/touch ${BASEDIR}/metaData/.reboot-request` | How the monitor triggers a reboot |
+
+Reboot without sudo (recommended):
+
+The monitor runs as a user LaunchAgent and does **not** perform the reboot
+itself — it only writes a reboot-request flag once the host is drained. A
+separate root job (`scheduled-reboot.sh`, invoked from a root crontab or
+LaunchDaemon every minute) consumes that flag and runs `/sbin/shutdown -r now`
+as root. Because that job is already privileged, no passwordless sudo is needed
+for the agent. `scheduled-reboot.sh` also keeps a nightly maintenance reboot as a
+time-based safety net.
+
+* Install `scheduled-reboot.sh` in your existing root scheduler, e.g. root crontab:
+
+  ```
+  * * * * * /path/to/mcloud-ios/scheduled-reboot.sh >/dev/null 2>&1
+  ```
 
 Prerequisites:
 
 * Auto-login must be enabled (see above) so LaunchAgents reload after the reboot.
-* The reboot must run **without a password prompt**. Grant passwordless sudo for
-  `shutdown`, e.g. add a file `/etc/sudoers.d/zebrunner-reboot` (via `sudo visudo -f`):
+* The root scheduler running `scheduled-reboot.sh` must be in place (as above).
+
+Alternative (no root job): set `HEALTH_REBOOT_CMD="sudo /sbin/shutdown -r now"`
+and grant passwordless sudo for `shutdown` via `/etc/sudoers.d/zebrunner-reboot`
+(add with `sudo visudo -f`):
 
   ```
   <your-user> ALL=(root) NOPASSWD: /sbin/shutdown

--- a/scheduled-reboot.sh
+++ b/scheduled-reboot.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# scheduled-reboot.sh
+#
+# Runs as ROOT from the host's existing scheduler (root crontab or a
+# LaunchDaemon), e.g. once a minute. It reboots the host when EITHER:
+#
+#   1. On demand  - the health monitor (health-monitor.sh, a user LaunchAgent)
+#      has drained the host and signalled that it is safe to reboot by creating
+#      the reboot-request flag. The monitor never needs sudo; only this
+#      already-privileged job performs the reboot.
+#
+#   2. Nightly    - a fixed maintenance window (CET) as a time-based safety net,
+#      independent of memory pressure.
+#
+# Install (example root crontab, every minute):
+#   * * * * * /Users/<user>/.../mcloud-ios/scheduled-reboot.sh >/dev/null 2>&1
+#
+# BASEDIR is derived from the script location, so the flag path always matches
+# the one written by the monitor (HEALTH_REBOOT_CMD in .env).
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REBOOT_FLAG="${BASEDIR}/metaData/.reboot-request"
+
+# Nightly maintenance window (CET / Europe/Paris)
+TARGET_HOUR=2
+TARGET_MINUTE=0
+
+# 1) On-demand reboot requested by the health monitor.
+#    Remove the flag first so a failed/slow shutdown does not loop and the flag
+#    never survives across the reboot.
+if [ -f "${REBOOT_FLAG}" ]; then
+  rm -f "${REBOOT_FLAG}"
+  logger -t zbr-reboot "Health monitor requested reboot (memory/swap drain complete); rebooting now"
+  /sbin/shutdown -r now
+  exit 0
+fi
+
+# 2) Nightly maintenance reboot. 10# forces base-10 so leading-zero values like
+#    "08"/"09" are not misparsed as invalid octal.
+read -r CURRENT_HOUR CURRENT_MINUTE <<< "$(TZ="Europe/Paris" date +"%H %M")"
+if (( 10#${CURRENT_HOUR} == TARGET_HOUR && 10#${CURRENT_MINUTE} == TARGET_MINUTE )); then
+  logger -t zbr-reboot "Nightly maintenance window; rebooting now"
+  /sbin/shutdown -r now
+fi

--- a/zebrunner.sh
+++ b/zebrunner.sh
@@ -679,9 +679,15 @@ export udid_position=2
     else
       echo "Host health: healthy (${HEALTH_LAST}) | uptime=$(uptime_minutes)min | drain=${drain_state}"
     fi
-    # Safe, non-executing check that the reboot command can run without a password.
-    if ! sudo -n -l /sbin/shutdown >/dev/null 2>&1; then
-      echo_warning "Passwordless sudo for /sbin/shutdown is NOT configured; auto-reboot will fail. See README (Health monitor)."
+    # Safe, non-executing check that the configured reboot path can actually fire.
+    if echo "${HEALTH_REBOOT_CMD}" | grep -q 'sudo'; then
+      if ! sudo -n -l /sbin/shutdown >/dev/null 2>&1; then
+        echo_warning "Passwordless sudo for /sbin/shutdown is NOT configured; auto-reboot will fail. See README (Health monitor)."
+      fi
+    elif echo "${HEALTH_REBOOT_CMD}" | grep -q 'reboot-request'; then
+      if [ ! -x "${BASEDIR}/scheduled-reboot.sh" ]; then
+        echo_warning "scheduled-reboot.sh is missing/not executable; the root scheduler cannot consume reboot requests. See README (Health monitor)."
+      fi
     fi
   }
 


### PR DESCRIPTION
Switch the default health-monitor reboot trigger from `sudo shutdown` to creating a `.reboot-request` flag, then add `scheduled-reboot.sh` to run as root and execute reboots (including the nightly maintenance window). Update README with the new recommended setup and fallback sudo option, and adjust `zebrunner.sh` warnings to validate either sudo-based rebooting or the presence of the root scheduler script.