### PR TITLE
Prevent screen recording process leaks

### DIFF
--- a/configs/health-common.sh
+++ b/configs/health-common.sh
@@ -215,19 +215,51 @@ deregister_idle_appium() {
   fi
 }
 
+# Stop any screen recording still running for a udid whose Appium we just killed.
+# Killing Appium means the session never emits DELETE /session, so the recording
+# watcher would never stop these -> they leak and keep the host from going idle.
+# SIGINT lets simctl finalize the mp4 cleanly; force-kill any straggler.
+stop_orphaned_recordings() {
+  local udid="$1"
+  [ -n "$udid" ] || return 0
+  local pids i
+  pids="$(pgrep -f "simctl io ${udid} recordVideo" 2>/dev/null)"
+  if [ -n "$pids" ]; then
+    hc_log "Stopping orphaned recording(s) for ${udid} during drain (pids: $(echo $pids | tr '\n' ' '))"
+    kill -INT $pids 2>/dev/null || true
+    i=0
+    while [ $i -lt 10 ] && pgrep -f "simctl io ${udid} recordVideo" >/dev/null 2>&1; do
+      sleep 0.5
+      i=$((i + 1))
+    done
+    pids="$(pgrep -f "simctl io ${udid} recordVideo" 2>/dev/null)"
+    [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
+  fi
+  # drop this udid's now-abandoned recording bookkeeping so drain can complete
+  rm -f "${BASEDIR}/recording/tmp/${udid}"/rec-*.pid \
+        "${BASEDIR}/recording/tmp/${udid}"/rec-*.timeout.pid 2>/dev/null || true
+}
+
 # True (0) when any screen recording or video transcoding is still in progress.
 recording_in_progress() {
   # Active simulator screen recording
   pgrep -f 'simctl io .* recordVideo' >/dev/null 2>&1 && return 0
   # Active transcoding
   pgrep -f 'ffmpeg' >/dev/null 2>&1 && return 0
-  # Pending transcode jobs or in-flight recordings tracked by the watcher
-  local f
+  # Pending transcode jobs tracked by the watcher
+  local f rpid
   for f in "${BASEDIR}"/recording/tmp/*/transcoder-jobs-*.list; do
     [ -f "$f" ] && [ -s "$f" ] && return 0
   done
+  # In-flight recordings: trust a pid file only if its process is actually alive
+  # (stale pid files from crashed/killed watchers must not block reboot forever).
   for f in "${BASEDIR}"/recording/tmp/*/rec-*.pid; do
-    [ -f "$f" ] && return 0
+    [ -f "$f" ] || continue
+    case "$f" in *.timeout.pid) continue ;; esac
+    rpid="$(cat "$f" 2>/dev/null)"
+    if [ -n "$rpid" ] && ps -p "$rpid" >/dev/null 2>&1; then
+      return 0
+    fi
   done
   return 1
 }

--- a/health-monitor.sh
+++ b/health-monitor.sh
@@ -70,6 +70,9 @@ run_drain_step() {
     else
       idle=$((idle + 1))
       deregister_idle_appium "$udid"
+      # its session can no longer emit DELETE /session, so finalize any recording
+      # left running for this udid instead of leaking it and blocking the reboot.
+      stop_orphaned_recordings "$udid"
     fi
   done < <(list_device_udid_port)
 

--- a/recording/mac-recording-watcher.sh
+++ b/recording/mac-recording-watcher.sh
@@ -377,6 +377,42 @@ stop_recording() {
   unmark_started_session "$rec_id"
 }
 
+# Each simulator is maxSession=1, so at most ONE recording should ever be active
+# for this udid. When a new session begins, any session still marked "started" is
+# orphaned (its DELETE /session was never observed: newCommandTimeout, client
+# crash, Appium restart, etc.) and must be stopped, otherwise simctl recordVideo
+# processes accumulate and exhaust memory.
+stop_prior_recordings() {
+  local keep="$1"
+  if [ -s "$STARTED_FILE" ]; then
+    local prev
+    # snapshot the list first: stop_recording() mutates STARTED_FILE
+    while IFS= read -r prev; do
+      [ -n "$prev" ] || continue
+      [ "$prev" = "$keep" ] && continue
+      log_warn "Orphaned prior recording $prev for ${TARGET_UDID}; stopping before starting $keep"
+      stop_recording "$prev"
+    done < <(cat "$STARTED_FILE")
+  fi
+}
+
+# Stop recordings left running by a previous watcher instance (its state files
+# were reset on restart, so those simctl processes are now untracked). Called
+# once at startup to reclaim leaked recordings.
+cleanup_preexisting_recordings() {
+  local pids
+  pids="$(pgrep -f "simctl io ${TARGET_UDID} recordVideo" 2>/dev/null)"
+  if [ -n "$pids" ]; then
+    log_warn "Startup: stopping $(echo $pids | wc -w | tr -d ' ') orphaned recording(s) for ${TARGET_UDID} from a previous run"
+    kill -INT $pids 2>/dev/null || true
+    sleep 2
+    pids="$(pgrep -f "simctl io ${TARGET_UDID} recordVideo" 2>/dev/null)"
+    [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
+  fi
+  # drop stale bookkeeping so recording_in_progress()/status checks stay accurate
+  rm -f "$STATE_DIR"/rec-*.pid "$STATE_DIR"/rec-*.timeout.pid 2>/dev/null || true
+}
+
 extract_session_id_from_line() {
   local line="$1"
   # Only accept: "Session created with session id: <uuid>"
@@ -403,6 +439,8 @@ handle_line() {
     debug_log "Matched session-created trigger; extracted sessionId: ${sid:-<none>}"
     if [ -n "$sid" ]; then
       if ! is_started_session "$sid"; then
+        # cap at one recording per simulator: stop any orphaned prior session
+        stop_prior_recordings "$sid"
         log_info "Detected session id $sid; starting recording"
         start_recording "$sid"
       else
@@ -675,6 +713,7 @@ trap 'terminate_all; exit 0' SIGINT SIGTERM EXIT
 
 log_info "Watching LOG_FILE: $LOG_FILE"
 kill_existing_watchers_for_udid
+cleanup_preexisting_recordings
 start_transcoder_worker
 start_retention_worker
 scan_and_tail_logs


### PR DESCRIPTION
Add cleanup logic to stop orphaned recordings at multiple points:

- Stop recordings when Appium is killed during drain (session won't emit DELETE /session)
- Stop prior orphaned recordings when a new session starts for the same simulator
- Clean up stale recordings left by previous watcher instances on startup
- Validate recording processes are alive before treating pid files as in-progress (fixes stale pid file issues)

These changes prevent simctl recordVideo processes from accumulating when sessions don't properly terminate.