### PR TITLE
Detect session-create failures in health checks

### DIFF
--- a/.env
+++ b/.env
@@ -27,3 +27,10 @@ HEALTH_DRAIN_TIMEOUT=1200
 # existing root scheduler (scheduled-reboot.sh, run from cron/LaunchDaemon)
 # consumes the flag and performs the actual /sbin/shutdown -r now as root.
 HEALTH_REBOOT_CMD="/usr/bin/touch ${BASEDIR}/metaData/.reboot-request"
+# Detect "healthy RAM but sessions won't create" (e.g. simulator cfprefsd out of
+# file descriptors). If a device's last N session-create attempts all failed,
+# the host is treated as unhealthy and drained/rebooted. Root fix for the FD
+# exhaustion itself is configs/limit.maxfiles.plist (see README).
+HEALTH_SESSION_FAIL_ENABLED=true
+HEALTH_SESSION_FAIL_MIN=6
+HEALTH_SESSION_TAIL_LINES=6000

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ Configuration (in `.env`):
 | `HEALTH_MEM_FREE_MIN_PCT` | `8` | Available RAM ≤ this % ⇒ unhealthy (`0` disables) |
 | `HEALTH_DRAIN_TIMEOUT` | `1800` | Force reboot after draining this long (stuck session safety valve) |
 | `HEALTH_REBOOT_CMD` | `/usr/bin/touch ${BASEDIR}/metaData/.reboot-request` | How the monitor triggers a reboot |
+| `HEALTH_SESSION_FAIL_ENABLED` | `true` | Also drain/reboot when sessions can't be created (even if RAM is fine) |
+| `HEALTH_SESSION_FAIL_MIN` | `6` | A device's last N `POST /session` all failing ⇒ unhealthy |
+| `HEALTH_SESSION_TAIL_LINES` | `6000` | Trailing Appium-log lines scanned per device for the check above |
+
+### Required: raise the open-file limit (`limit.maxfiles`)
+
+macOS defaults the per-process open-file soft limit to **256**. Every booted
+simulator's `cfprefsd` inherits it and, during long regression runs, accumulates
+descriptors until it hits 256. After that, any `defaults write` to that simulator
+fails with `Could not write domain ... exiting` and Appium can no longer create
+sessions (`POST /session 500`) — while RAM/swap still look perfectly healthy. The
+health monitor will detect this and reboot (see `HEALTH_SESSION_FAIL_*`), but the
+real fix is to raise the limit so it never happens:
+
+```bash
+sudo cp configs/limit.maxfiles.plist /Library/LaunchDaemons/limit.maxfiles.plist
+sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+sudo chmod 644        /Library/LaunchDaemons/limit.maxfiles.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/limit.maxfiles.plist
+sudo reboot   # required so launchd_sim/cfprefsd inherit the new limit
+# verify after reboot:
+launchctl limit maxfiles      # -> 65536 65536
+```
 
 Reboot without sudo (recommended):
 

--- a/configs/health-common.sh
+++ b/configs/health-common.sh
@@ -42,9 +42,17 @@ export DRAIN_FLAG="${BASEDIR}/metaData/.drain"
 : "${HEALTH_DRAIN_TIMEOUT:=1800}"      # force reboot after draining this long (seconds)
 : "${HEALTH_REBOOT_CMD:=sudo /sbin/shutdown -r now}"
 
+# Session-creation-failure signal: detect an environment that reports healthy RAM
+# but can no longer create Appium sessions (e.g. simulator cfprefsd out of file
+# descriptors -> "Could not write domain ... exiting" -> POST /session 500).
+: "${HEALTH_SESSION_FAIL_ENABLED:=true}"
+: "${HEALTH_SESSION_FAIL_MIN:=6}"      # last N session-create results all failed => unhealthy
+: "${HEALTH_SESSION_TAIL_LINES:=6000}" # how many trailing appium-log lines to scan per device
+
 # Cross-call scratch values populated by is_host_unhealthy().
 export HEALTH_LAST=""
 export HEALTH_REASON=""
+export HEALTH_SESSION_INFO=""
 
 hc_timestamp() { date "+%Y-%m-%dT%H:%M:%S%z"; }
 
@@ -160,12 +168,41 @@ is_host_unhealthy() {
     if [ -n "$reasons" ]; then reasons="${reasons}, "; fi
     reasons="${reasons}free_ram=${free_pct}%<=${HEALTH_MEM_FREE_MIN_PCT}%"
   fi
+  # Environment can report healthy RAM yet be unable to create sessions.
+  if session_creation_failing; then
+    if [ -n "$reasons" ]; then reasons="${reasons}, "; fi
+    reasons="${reasons}session_creation_failing (${HEALTH_SESSION_INFO})"
+  fi
 
   if [ -n "$reasons" ]; then
     HEALTH_REASON="$reasons"
     return 0
   fi
   HEALTH_REASON=""
+  return 1
+}
+
+# True (0) when at least one device's most recent session-creation attempts all
+# failed. Signature of simulator/cfprefsd degradation that leaves RAM untouched.
+# Only flags a device that actually attempted HEALTH_SESSION_FAIL_MIN sessions
+# recently and got zero 2xx among them, so idle devices never trip it.
+session_creation_failing() {
+  HEALTH_SESSION_INFO=""
+  [ "${HEALTH_SESSION_FAIL_ENABLED}" = "true" ] || return 1
+  local f results count k="${HEALTH_SESSION_FAIL_MIN}"
+  for f in "${BASEDIR}"/logs/appium-*.log; do
+    [ -f "$f" ] || continue
+    # last k HTTP response codes for POST /wd/hub/session in the recent tail
+    results="$(tail -n "${HEALTH_SESSION_TAIL_LINES}" "$f" 2>/dev/null \
+      | grep -Eo 'POST /wd/hub/session [0-9]{3}' | awk '{print $NF}' | tail -n "$k")"
+    count="$(printf '%s\n' "$results" | grep -c .)"
+    [ "$count" -ge "$k" ] || continue
+    # none of the last k attempts succeeded (2xx) -> this device is broken
+    if ! printf '%s\n' "$results" | grep -q '^2'; then
+      HEALTH_SESSION_INFO="$(basename "$f" | sed 's/^appium-//; s/\.log$//')=last${k}_failed"
+      return 0
+    fi
+  done
   return 1
 }
 

--- a/configs/limit.maxfiles.plist
+++ b/configs/limit.maxfiles.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+	"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Raises the per-process open-file (RLIMIT_NOFILE) soft/hard limit for every
+  process launched by launchd, including each iOS Simulator's launchd_sim and
+  its cfprefsd.
+
+  Why this is required for a simulator farm:
+    macOS ships a soft maxfiles limit of 256. Every booted simulator's cfprefsd
+    inherits it. During long regression runs cfprefsd accumulates preference
+    clients/descriptors and eventually hits 256 open files. Once capped, any
+    `defaults write` to that simulator fails with
+        "Could not write domain ...; exiting"
+    and Appium can no longer create sessions (POST /session 500) even though RAM
+    and swap look perfectly healthy.
+
+  Install (one-time, as root):
+    sudo cp configs/limit.maxfiles.plist /Library/LaunchDaemons/limit.maxfiles.plist
+    sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+    sudo chmod 644       /Library/LaunchDaemons/limit.maxfiles.plist
+    sudo launchctl bootstrap system /Library/LaunchDaemons/limit.maxfiles.plist
+    # then REBOOT so launchd_sim/cfprefsd for the simulators inherit the new limit
+
+  Verify after reboot:
+    launchctl limit maxfiles      # -> 65536 65536
+-->
+<plist version="1.0">
+	<dict>
+		<key>Label</key>
+		<string>limit.maxfiles</string>
+		<key>ProgramArguments</key>
+		<array>
+			<string>launchctl</string>
+			<string>limit</string>
+			<string>maxfiles</string>
+			<string>65536</string>
+			<string>65536</string>
+		</array>
+		<key>RunAtLoad</key>
+		<true/>
+		<key>ServiceIPC</key>
+		<false/>
+	</dict>
+</plist>


### PR DESCRIPTION
Extend host health evaluation to mark machines unhealthy when a device’s last N Appium `POST /session` attempts all fail, even if RAM metrics look fine. This adds configurable `HEALTH_SESSION_FAIL_*` settings in `.env`, wires failure detection into `health-common.sh`, and records per-device failure context. Also add `configs/limit.maxfiles.plist` plus README guidance to raise macOS `maxfiles` limits so simulator `cfprefsd` no longer hits FD exhaustion that causes repeated session creation 500s.